### PR TITLE
clone from https url

### DIFF
--- a/busy.yaml
+++ b/busy.yaml
@@ -1,6 +1,6 @@
 name: ThreadPool
 extRepositories:
-  - url: git@github.com:SGSSGene/gtest.git
+  - url: https://github.com/SGSSGene/gtest.git
 projects:
   - name: threadPool
     depLibraries:


### PR DESCRIPTION
simplify installing for users that just want to use threadpool as a tool
